### PR TITLE
#1 Problema no cadastro de clientes

### DIFF
--- a/src/Services/Axios/clientServices.js
+++ b/src/Services/Axios/clientServices.js
@@ -82,6 +82,11 @@ export async function postClient(
     } else if (error.response.status !== 401) {
       startModal('Não foi possivel criar o cliente. Tente novamente mais tarde');
     }
+
+    if (error.response.status === 400 && error.response.data.message[0] === 'invalid cpf') {
+      startModal('CPF Invalido');
+    }
+
     console.error(`An unexpected error ocourred while creating a new client.${error}`);
   }
   return false;


### PR DESCRIPTION
Co-authored-by: Pedro <phlimas@outlook.com>

**Issue:** Problema no cadastro de clientes #1

## Descrição

O Cadastro de cliente não possuía uma mensagem de retorno adequada quando o CPF era invalido. Agora o retorno da mensagem é especifica para esse tipo de situação.