### PR TITLE
Resolução da adequação da atualização da demanda

### DIFF
--- a/src/Components/NewUpdateCard/index.js
+++ b/src/Components/NewUpdateCard/index.js
@@ -17,7 +17,7 @@ const NewUpdateCard = ({
   demand, getDemandApi, changeState, setChangeState,
 }) => {
   const [description, setDescription] = useState('');
-  const [visibilityRestriction, setVisibilityRestriction] = useState(true);
+  const [visibilityRestriction, setVisibilityRestriction] = useState(false);
   const [important, setImportant] = useState(false);
   const [uploadFile, setUploadFile] = useState('');
   const [openModal, setOpenModal] = useState(false);
@@ -81,7 +81,6 @@ const NewUpdateCard = ({
                 (
                   <Checkbox
                     value={visibilityRestriction}
-                    defaultChecked
                     onClick={() => setVisibilityRestriction(!visibilityRestriction)}
                     inputProps={{ 'aria-label': 'Checkbox A' }}
                     style={{ color: `${colors.navHeaders}` }}

--- a/src/Services/Axios/demandsServices.js
+++ b/src/Services/Axios/demandsServices.js
@@ -337,7 +337,7 @@ export async function DemandUploadFile(
       startModal('O tempo da sua sessão expirou, faça o login novamente');
     } else {
       // eslint-disable-next-line no-undef
-      startModal('Erro ao anexar PDF.');
+      startModal('O arquivo ultrapassou o limite de 5MB.');
     }
   }
 }


### PR DESCRIPTION
## Descrição

Este PR resolve a issue [#44](https://github.com/DITGO/2021-2-SiGeD-Doc/issues/44), que consiste na adequação da atualização da demanda deixando a checkbox "Visível somente para o meu setor" desmarcada por padrão, por meio do seguinte commit:

* [Resolução referente à issue #44](https://github.com/2023-1-GCES-SIGeD/2021-2-SiGeD-Frontend/commit/be4ecd774011b38f17965af14f7f380b85f92e3c)  - Frontend

## Como isso foi testado
* Acessando a página da demanda;
* Criando uma atualização de demanda e checando se a atualização era visível ou não para o setor;

## Capturas de tela
![Screenshot from 2023-06-28 23-20-35](https://github.com/DITGO/2021-2-SiGeD-Frontend/assets/21300624/6ac03f47-809e-43a5-b93e-e402f19a5a3c)

## Tipos de mudança
A partir de agora, ao atualizar a demanda a opção "Visível somente para o meu setor" estará, por padrão, desmarcada.

### Pareamento: @brunaalmeidasantos