### PR TITLE
Adição de imprimir todas as demandas por cliente

### DIFF
--- a/src/Components/ClientDemandData/index.js
+++ b/src/Components/ClientDemandData/index.js
@@ -1,10 +1,15 @@
 import moment from 'moment-timezone';
 import { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
+import { FaPrint } from 'react-icons/fa';
 import {
   DemandDiv, SectorNameDiv, CategoriesDiv, CategoryTag, styles,
 } from './Style';
-import { DemandTitle, ProcessNumber, DemandCreatedAt } from '../DemandData/Style';
+import {
+  DemandTitle, ProcessNumber, DemandCreatedAt, Button, Icon,
+} from '../DemandData/Style';
+import { DemandReport } from '../../Utils/reports/printDemandReport';
+import { useProfileUser } from '../../Context';
 
 const ClientDemandData = ({ demand, sectors, style }) => {
   const history = useHistory();
@@ -13,12 +18,18 @@ const ClientDemandData = ({ demand, sectors, style }) => {
   const renderDemandCategories = () => (demand.categoryID?.map((category) => (
     <CategoryTag color={category.color}>{category.name}</CategoryTag>
   )));
+  const { user, startModal } = useProfileUser();
 
   useEffect(() => {
   }, [sectorName]);
 
   return (
     <DemandDiv onClick={() => history.push(`/visualizar/${demand._id}`)} style={style}>
+      <Button onClick={() => DemandReport(demand._id, user, startModal)}>
+        <Icon color="#000">
+          <FaPrint />
+        </Icon>
+      </Button>
       <DemandTitle>
         {demand.name}
       </DemandTitle>

--- a/src/Components/ClientDemandData/index.js
+++ b/src/Components/ClientDemandData/index.js
@@ -25,11 +25,13 @@ const ClientDemandData = ({ demand, sectors, style }) => {
 
   return (
     <DemandDiv onClick={() => history.push(`/visualizar/${demand._id}`)} style={style}>
-      <Button onClick={() => DemandReport(demand._id, user, startModal)}>
-        <Icon color="#000">
-          <FaPrint />
-        </Icon>
-      </Button>
+      <abbr title="Imprimir relatório dessa demanda">
+        <Button onClick={() => DemandReport(demand._id, user, startModal)}>
+          <Icon color="#000">
+            <FaPrint />
+          </Icon>
+        </Button>
+      </abbr>
       <DemandTitle>
         {demand.name}
       </DemandTitle>

--- a/src/Components/DemandData/index.js
+++ b/src/Components/DemandData/index.js
@@ -1,22 +1,27 @@
 import { Link } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
 import moment from 'moment-timezone';
-import { FaPrint } from 'react-icons/fa';
+import { FaPrint, FaFilePdf } from 'react-icons/fa';
 import {
   DemandCard, DemandTitle, ClientName, SectorName, ProcessNumber,
   DemandCreatedAt, CategoryField, CategoryName, Icon, Button,
 } from './Style';
 import colors from '../../Constants/colors';
-import { DemandReport } from '../../Utils/reports/printDemandReport';
+import { getDemandsWithClientsNames } from '../../Services/Axios/demandsServices';
+import { AllDemandsPerClient, DemandReport } from '../../Utils/reports/printDemandReport';
 import { useProfileUser } from '../../Context';
 
 const DemandData = ({ demand, sectors }) => {
-  const { user, startModal } = useProfileUser();
+  const { token, user, startModal } = useProfileUser();
   const sectorName = sectors?.filter((sectorByID) => (sectorByID._id
     === demand.sectorHistory.at(-1).sectorID));
 
   const renderDemandCategories = () => (demand.categoryID?.map((category) => (
     <CategoryName color={category.color}>{category.name}</CategoryName>
   )));
+  const [query] = useState('');
+  const [demands, setDemands] = useState([]);
+  const getDemandsFromApi = () => getDemandsWithClientsNames(`clientsNames?open=${query}`, startModal);
 
   const styles = {
     demandCard: {
@@ -34,6 +39,14 @@ const DemandData = ({ demand, sectors }) => {
     },
   };
 
+  useEffect(async () => {
+    if (token && user) {
+      const result = await Promise.all([
+        getDemandsFromApi()]);
+      setDemands(result[0].data);
+    }
+  }, [token, user]);
+
   return (
     <DemandCard
       as={Link}
@@ -43,6 +56,14 @@ const DemandData = ({ demand, sectors }) => {
       <Button onClick={() => DemandReport(demand._id, user, startModal)}>
         <Icon color="#000">
           <FaPrint />
+        </Icon>
+      </Button>
+
+      <Button onClick={() => AllDemandsPerClient(
+        demand.clientID, demands, user, startModal,
+      )}>
+        <Icon color="#000">
+          <FaFilePdf />
         </Icon>
       </Button>
 

--- a/src/Components/DemandData/index.js
+++ b/src/Components/DemandData/index.js
@@ -53,19 +53,23 @@ const DemandData = ({ demand, sectors }) => {
       to={`/visualizar/${demand._id}`}
       style={styles.demandCard}
     >
-      <Button onClick={() => DemandReport(demand._id, user, startModal)}>
-        <Icon color="#000">
-          <FaPrint />
-        </Icon>
-      </Button>
+      <abbr title="Imprimir relatório dessa demanda">
+        <Button onClick={() => DemandReport(demand._id, user, startModal)}>
+          <Icon color="#000">
+            <FaPrint />
+          </Icon>
+        </Button>
+      </abbr>
 
-      <Button onClick={() => AllDemandsPerClient(
-        demand.clientID, demands, user, startModal,
-      )}>
-        <Icon color="#000">
-          <FaFilePdf />
-        </Icon>
-      </Button>
+      <abbr title="Imprimir relatório de todas as demandas desse cliente">
+        <Button onClick={() => AllDemandsPerClient(
+          demand.clientID, demands, user, startModal,
+        )}>
+          <Icon color="#000">
+            <FaFilePdf />
+          </Icon>
+        </Button>
+      </abbr>
 
       <DemandTitle>
         {demand.name}

--- a/src/Pages/ClientProfileScreen/Style.js
+++ b/src/Pages/ClientProfileScreen/Style.js
@@ -164,3 +164,27 @@ export const styles = {
     fontSize: '100%',
   },
 };
+
+export const Button = styled.button`
+  display: flex;
+  border: none;
+  border-radius: 4px;
+  margin-left: 5%;
+  background-color: #1F3541;
+  color: white;
+  font-size: 1.5vh;
+  padding: 5px;
+  width: 50%;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: filter 0.2s;
+
+  &:hover {
+    filter: brightness(80%);
+  }
+
+  @media(max-width: 750px){
+    font-size: 1.3vh;
+  }
+`;

--- a/src/Pages/ClientProfileScreen/index.js
+++ b/src/Pages/ClientProfileScreen/index.js
@@ -10,7 +10,7 @@ import RedirectListButton from '../../Components/RedirectButton';
 import DropdownComponent from '../../Components/DropdownComponent';
 import {
   Main, RightBox, RightBoxMain, TitleH, SearchDiv, FilterDiv,
-  HeaderDiv, ListDiv, ButtonContainer, ContainerDiv, styles,
+  HeaderDiv, ListDiv, ButtonContainer, ContainerDiv, styles, Button,
 } from './Style';
 import { DropdownField } from '../ListDemandsScreen/Style';
 import { DropDiv, ContentBox } from '../../Components/GenericListScreen/Style';
@@ -21,6 +21,7 @@ import { getSectors } from '../../Services/Axios/sectorServices';
 import { useProfileUser } from '../../Context';
 import colors from '../../Constants/colors';
 import ClientHistory from '../../Components/ClientHistory';
+import { AllDemandsPerClient } from '../../Utils/reports/printDemandReport';
 
 const ClientProfileScreen = () => {
   const [sectors, setSectors] = useState([]);
@@ -45,7 +46,7 @@ const ClientProfileScreen = () => {
   const [clientFeatures, setClientFeatures] = useState([]);
   const [clientFeaturesID, setClientFeaturesID] = useState([]);
   const { id } = useParams();
-  const { startModal } = useProfileUser();
+  const { user, startModal } = useProfileUser();
   const [show, setShow] = useState(false);
   const handleClose = () => setShow(false);
   const handleShow = () => setShow(true);
@@ -209,6 +210,11 @@ const ClientProfileScreen = () => {
                           setWord={(value) => setWord(value)}
                         />
                       </SearchDiv>
+                      <Button onClick={() => AllDemandsPerClient(
+                        client._id, demands, user, startModal,
+                      )}>
+                        Gerar Relatório
+                      </Button>
                     </DropDiv>
                     <FilterDiv>
                       <DropdownField width="35%">


### PR DESCRIPTION
## Descrição

Este PR resolve as issues [05](https://github.com/Siged-Gces-2023-2/2023.2-SIGeD-GCES-Doc/issues/5) e [09](https://github.com/Siged-Gces-2023-2/2023.2-SIGeD-GCES-Doc/issues/9) que consite em permitir a impressão de todas as demandas de um determinado cliente. 

## Tela de demandas:

Ao listar o prontuário do cliente com as demandas criadas seja apresentado um botão para impressão de todas as demandas agrupadas para aquele cliente.

### Como foi testado

- Acessando a pagina de perfil do cliente
- Clicando no botão "Gerar Relatorio" ao lado do pesquisar cliente
- Clicando no botão de imprimir umademanda do cliente para cada demanda presente

### Capturas de tela

![antes](https://github.com/DITGO/2021-2-SiGeD-Frontend/assets/79341819/c8152796-e762-480e-a5c6-5dea8a2421bc)
![pdf](https://github.com/DITGO/2021-2-SiGeD-Frontend/assets/79341819/2ef0b647-c458-4c2e-acee-50065ec34d56)

## Tela do Cliente

Dentro da tela de perfil de um cliente, ao listar todas as demandas vinculada à aquele cliente, foi adicionado um botão "Gerar Relatório" e um botão de impressão única para cada demanda pertencente ao cliente.

### Como foi testado

- Acessando a pagina de demanda
- Clicando no botão de imprimir todas demandas por cliente para cada demanda presente

### Capturas de tela

![msg1929553048-13255](https://github.com/DITGO/2021-2-SiGeD-Frontend/assets/79341819/a469c568-462f-4fd1-860f-66f4ee2476cf)

### Pareamento: @luclopesr 

### Issues resolvidas com o PR

Repositório DITGO:
resolves DITGO/2021-2-SiGeD-Doc/issues/48
resolves DITGO/2021-2-SiGeD-Doc/issues/24

Respositório GCES-2023/2:
resolves Siged-Gces-2023-2/2023.2-SIGeD-GCES-Doc/issues/5
resolves Siged-Gces-2023-2/2023.2-SIGeD-GCES-Doc/issues/9