### PR TITLE
Incluir atendimentos dentro da demanda

### DIFF
--- a/src/Components/ErrorMessage/index.js
+++ b/src/Components/ErrorMessage/index.js
@@ -1,6 +1,7 @@
 import styles from './Style';
 import {
   validateName, validateEmail, validatePassword, confirmPassword,
+  validateStringTel, validateStringCpf,
 } from '../../Utils/validations';
 
 export function ErrorMessage({ input, title }) {
@@ -8,15 +9,15 @@ export function ErrorMessage({ input, title }) {
     case 'Nome':
       if (input && !validateName(input)) {
         return (
-          <p style={styles.text}>Credenciais Inválidas, nome deve possuir mais de 2 a 50 letras!</p>
+          <p style={styles.text}>Nome Inválido, ele deve possuir entre 2 a 50 letras!</p>
         );
       }
       break;
 
-    case 'Email':
+    case 'E-mail':
       if (input && !validateEmail(input)) {
         return (
-          <p style={styles.text}>Credenciais Inválidas</p>
+          <p style={styles.text}>Email Inválido</p>
         );
       }
       break;
@@ -24,7 +25,23 @@ export function ErrorMessage({ input, title }) {
     case 'Senha':
       if (input && !validatePassword(input)) {
         return (
-          <p style={styles.text}>Credenciais Inválidas</p>
+          <p style={styles.text}>Senha Inválida</p>
+        );
+      }
+      break;
+
+    case 'CPF':
+      if (input && !validateStringCpf(input)) {
+        return (
+          <p style={styles.text}>CPF Inválido, ele deve possuir 11 números!</p>
+        );
+      }
+      break;
+
+    case 'telefone':
+      if (input && !validateStringTel(input)) {
+        return (
+          <p style={styles.text}>Telefone Inválido, ele deve possuir mais de 10 numeros!</p>
         );
       }
       break;

--- a/src/Components/ModalEditUpdateDemand/index.js
+++ b/src/Components/ModalEditUpdateDemand/index.js
@@ -21,11 +21,13 @@ const ModalEditUpdateDemand = ({
   setChangeState,
   changeState,
   important,
+  treatment,
 }) => {
   const [updateDescription, setUpdateDescription] = useState(description);
   const [updateVisibility, setUpdateVisibility] = useState(true);
   const { user, startModal } = useProfileUser();
   const [editedImportant, seteditedImportant] = useState(important);
+  const [editedTreatment, setEditTreatment] = useState(treatment);
 
   const styles = {
     checkBox: {
@@ -44,7 +46,7 @@ const ModalEditUpdateDemand = ({
   const editUpdate = async () => {
     updateDemandUpdate(
       name, userSector, user._id, updateDescription, demandID,
-      updateDemandID, updateVisibility, editedImportant, startModal,
+      updateDemandID, updateVisibility, editedImportant, editedTreatment, startModal,
     );
     setUpdateVisibility(true);
     handleClose();
@@ -97,6 +99,22 @@ const ModalEditUpdateDemand = ({
                   )
                 }
                 label="Importante"
+              />
+            </CheckboxContainer>
+            <CheckboxContainer>
+              <FormControlLabel
+                control={
+                  (
+                    <Checkbox
+                      value={editedTreatment}
+                      defaultChecked={treatment}
+                      onClick={() => setEditTreatment(!editedTreatment)}
+                      inputProps={{ 'aria-label': 'Checkbox A' }}
+                      style={styles.checkBox}
+                    />
+                  )
+                }
+                label="Atendimento"
               />
             </CheckboxContainer>
           </CheckboxDiv>

--- a/src/Components/NewUpdateCard/index.js
+++ b/src/Components/NewUpdateCard/index.js
@@ -19,6 +19,7 @@ const NewUpdateCard = ({
   const [description, setDescription] = useState('');
   const [visibilityRestriction, setVisibilityRestriction] = useState(false);
   const [important, setImportant] = useState(false);
+  const [treatment, setTreatment] = useState(false);
   const [uploadFile, setUploadFile] = useState('');
   const [openModal, setOpenModal] = useState(false);
   const { user, startModal } = useProfileUser();
@@ -28,7 +29,7 @@ const NewUpdateCard = ({
       return;
     }
     createDemandUpdate(user.name, user.sector, user._id, description,
-      visibilityRestriction, demand._id, important, startModal);
+      visibilityRestriction, demand._id, important, treatment, startModal);
     getDemandApi();
     setDescription('');
   };
@@ -42,6 +43,7 @@ const NewUpdateCard = ({
         description: uploadFile.name,
         important,
         visibility: visibilityRestriction,
+        treatment,
       };
 
       DemandUploadFile(demand._id, startModal, uploadFile, info);
@@ -106,6 +108,21 @@ const NewUpdateCard = ({
                 )
               }
               label="Importante"
+            />
+          </CheckboxContainer>
+          <CheckboxContainer>
+            <FormControlLabel
+              control={
+                (
+                  <Checkbox
+                    value={treatment}
+                    onClick={() => setTreatment(!treatment)}
+                    inputProps={{ 'aria-label': 'Checkbox A' }}
+                    style={{ color: `${colors.navHeaders}` }}
+                  />
+                )
+              }
+              label="Atendimento"
             />
           </CheckboxContainer>
         </CheckboxDiv>

--- a/src/Components/TelephoneInput/index.js
+++ b/src/Components/TelephoneInput/index.js
@@ -53,7 +53,7 @@ const TelephoneInput = ({
           outline: '0',
         }}
       />
-      <ErrorMessage input={value} title={title} />
+      <ErrorMessage input={value} title="telefone" />
     </Container>
   );
 };

--- a/src/Components/UpdateCard/index.js
+++ b/src/Components/UpdateCard/index.js
@@ -137,6 +137,13 @@ const UpdateCard = ({
               </LockIcon>
             )
             : null }
+          { update.treatment
+            ? (
+              <HighPriorityIcon>
+                <FcHighPriority style={styles.iconStyle} />
+              </HighPriorityIcon>
+            )
+            : null }
           { fileID.length === 1 ? (
             <EditIcon
               onClick={() => { setFileStatus(true); }}
@@ -183,6 +190,7 @@ const UpdateCard = ({
         setChangeState={setChangeState}
         changeState={changeState}
         important={update.important}
+        treatment={update.treatment}
       />
       <ConfirmDemandModal
         show={confirm}

--- a/src/Services/Axios/demandsServices.js
+++ b/src/Services/Axios/demandsServices.js
@@ -239,6 +239,7 @@ export async function createDemandUpdate(
   visibilityRestriction,
   id,
   important,
+  treatment,
   startModal,
 ) {
   try {
@@ -249,6 +250,7 @@ export async function createDemandUpdate(
       description,
       visibilityRestriction,
       important,
+      treatment,
     });
     if (response.data.status) {
       startModal('Preencha o campo de descrição da atualização para ser possível o envio.');
@@ -324,6 +326,7 @@ export async function DemandUploadFile(
     dataArray.append('description', info.description);
     dataArray.append('important', info.important);
     dataArray.append('visibility', info.visibility);
+    dataArray.append('treatment', info.treatment);
 
     dataArray.append('file', file);
 
@@ -351,6 +354,7 @@ export async function updateDemandUpdate(
   updateListID,
   visibilityRestriction,
   important,
+  treatment,
   startModal,
 ) {
   try {
@@ -362,6 +366,7 @@ export async function updateDemandUpdate(
       visibilityRestriction,
       updateListID,
       important,
+      treatment,
     });
     if (response.data.status) {
       startModal('Não foi possível editar a atualização.');

--- a/src/Utils/validations.js
+++ b/src/Utils/validations.js
@@ -25,6 +25,20 @@ export const validatePassword = (pass) => {
   return false;
 };
 
+export const validateStringCpf = (cpf) => {
+  if (cpf.length === 14) {
+    return true;
+  }
+  return false;
+};
+
+export const validateStringTel = (tel) => {
+  if (tel.length >= 10) {
+    return true;
+  }
+  return false;
+};
+
 export const confirmPassword = (pass1, pass2) => {
   if (pass2 === pass1) {
     return true;


### PR DESCRIPTION
## Descrição

Esse PR resolve a issue [4](https://github.com/Siged-Gces-2023-2/2023.2-SIGeD-GCES-Doc/issues/4) que consiste em adicionar um checkbox de atendimento na atualização das demandas e além disso contabilizar os atendimentos.

## Tela de atualização de demandas:

Ao entrar em uma demanda específica, o usuário é capaz de adicionar atendimento à demanda.

## Como foi testado:

* Acessando uma demanda específica
* Preenchendo o checkbox de atendimento e atualizando a demanda
* Visualizando a edição da nova atualização de demanda

## Capturas de tela:
![Captura de tela de 2023-10-19 11-04-25](https://github.com/DITGO/2021-2-SiGeD-Frontend/assets/81006095/4c3b19fe-8648-4137-971f-dbe544f0d1f6)
![Captura de tela de 2023-10-19 12-59-15](https://github.com/DITGO/2021-2-SiGeD-Frontend/assets/81006095/2e59cf2f-30ff-4cba-bb7e-b53922b30ce5)
![Captura de tela de 2023-10-19 12-59-29](https://github.com/DITGO/2021-2-SiGeD-Frontend/assets/81006095/9a433642-c876-4c3f-b510-36eb1575f873)
![Captura de tela de 2023-10-19 12-59-33](https://github.com/DITGO/2021-2-SiGeD-Frontend/assets/81006095/f0369c6a-e9e1-49ff-8c94-35b954f321d4)

# Pareamento: @brbsg

## Issue resolvidas com o PR

Repositório DITGO:
resolve https://github.com/DITGO/2021-2-SiGeD-Doc/issues/26

Repositório GCES-2023/2:
resolve https://github.com/Siged-Gces-2023-2/2023.2-SIGeD-GCES-Doc/issues/4


