### PR TITLE
Ajuste do posicionamento do botão Gerar PDF na tela de Patrimônio

### DIFF
--- a/src/Components/ClientForms/index.js
+++ b/src/Components/ClientForms/index.js
@@ -97,7 +97,7 @@ const ClientForms = ({
           >
             {!register
               ? <option selected disabled hidden value={cargoInicial}>{cargoInicial}</option>
-              : <option hidden disabled selected value> </option>}
+              : <option hidden disabled selected value>Selecione</option>}
             { cargos ? cargos.map((cargo) => (
               <option value={cargo.name}>{cargo.name}</option>
             )) : null }
@@ -117,7 +117,7 @@ const ClientForms = ({
           >
             {!register
               ? <option selected disabled hidden value={idLot}>{nomeLotacaoinicial}</option>
-              : <option hidden disabled selected value> </option>}
+              : <option hidden disabled selected value>Selecione</option>}
             {lotacao ? lotacao.map((lot) => (
               <option value={lot._id}>{lot.name}</option>
             )) : null}

--- a/src/Pages/PatrimonyScreen/Style.js
+++ b/src/Pages/PatrimonyScreen/Style.js
@@ -48,10 +48,19 @@ export const Button = styled.div`
   height: 5vh;
   display: flex;
   flex-direction: row;
+  justify-content: center;
   align-items: center;
   padding: 8px 16px;
   border: none;
-  border-radius: 14px;
   cursor: pointer;
+  position: absolute;
+  top: 25.5%;
+  right: 240px;
+  height: 50px;
+  border-radius: 15px;
 
+  @media(max-width: 750px){
+    top: 16%;
+    right: 38%;
+  }
 `;

--- a/src/Pages/PatrimonyScreen/index.js
+++ b/src/Pages/PatrimonyScreen/index.js
@@ -72,6 +72,7 @@ const PatrimonyScreen = () => {
 
   return (
     <>
+      <Button onClick={generatePDF}>Gerar PDF</Button>
       <GenericListScreen
         ButtonTitle="Novo Patrimônio"
         ButtonFunction={toggleModal}
@@ -109,10 +110,6 @@ const PatrimonyScreen = () => {
           />
         ) : null}
       </GenericListScreen>
-
-      <div style={{ position: 'fixed', bottom: '10px', right: '6%' }}>
-        <Button onClick={generatePDF}>Gerar PDF</Button>
-      </div>
     </>
   );
 };


### PR DESCRIPTION
# Descrição
Este PR resolve a issue [#16](https://github.com/Siged-Gces-2023-2/2023.2-SIGeD-GCES-Doc/issues/16) que consiste em ajustar o posicionamento do botão Gerar PDF na tela de Patrimônio, colocando ao lado do botão "Novo Patrimônio"
- Pareamento: @DaviSilva25 

# Objetivo
Facilitar a utilização do recurso e tornar o ambiente mais intuitivo, dispondo todos os botões próximos.

# Captura de tela
![img](https://github.com/DITGO/2021-2-SiGeD-Frontend/assets/88348202/709dab83-8da3-463b-a27d-b3f845c361b9)

# Issue resolvidas
- Repositório DITGO:
resolves https://github.com/DITGO/2021-2-SiGeD-Doc/issues/54
- Repositório GCES-2023/2:
resolves https://github.com/Siged-Gces-2023-2/2023.2-SIGeD-GCES-Doc/issues/16